### PR TITLE
Simplify Dockerfile and remove 'entrypoint.sh'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,5 @@
-# Base image
-FROM ubuntu:latest
+FROM mariadb:latest
 
-# Updating and installing necessary software
-RUN apt-get update && apt-get install -y \
-	mariadb-server \
-	mariadb-client \
-    dos2unix
-
-
-# Allow to use all databases
-RUN echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
-
-# Bind MariaDB to all interfaces
-RUN echo "[mysqld]\nbind-address=0.0.0.0" >> /etc/mysql/mariadb.conf.d/99_mariadb.cnf
-
-# Copy shell script to image and set it to entrypoint
-COPY conf/entrypoint.sh /
-RUN chmod +x /entrypoint.sh && \
-    dos2unix /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-
-# Expose port 3306
 EXPOSE 3306
+
+CMD ["mariadbd"]

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo 'Début entrypoint.sh'
-# Start MariaDB
-service mariadb start
-
-echo 'Fin entrypoint.sh'


### PR DESCRIPTION
The Dockerfile has been simplified to use the latest MariaDB image rather than Ubuntu, eliminating the need for the 'entrypoint.sh' file. As a result, 'entrypoint.sh' has been deleted, and the database setup within it is now unnecessary. Additionally, the Dockerfile has been streamlined for cleaner usage with fewer command statements.